### PR TITLE
Fix typo

### DIFF
--- a/DOLLoader.xcodeproj/project.pbxproj
+++ b/DOLLoader.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 					"$(SRCROOT)/../include",
 				);
 				INFOPLIST_FILE = "DOL_Loader/DOLLoader-Info.plist";
-				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/V4/Loaders";
+				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/v4/Loaders";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sappharad.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = DOLLoader;
 				WRAPPER_EXTENSION = hopperLoader;
@@ -278,7 +278,7 @@
 					"$(SRCROOT)/../include",
 				);
 				INFOPLIST_FILE = "DOL_Loader/DOLLoader-Info.plist";
-				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/V4/Loaders";
+				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/v4/Loaders";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sappharad.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = DOLLoader;
 				WRAPPER_EXTENSION = hopperLoader;


### PR DESCRIPTION
The plugin installation path should be v4, not V4. PPCCPU has this correct already.

(Thank you for updating it to v4, by the way!)