### PR TITLE
Implement mr. instruction and data section address parsing

### DIFF
--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -556,7 +556,8 @@ static int GetRegisterIndex(DisasmOperandType type)
             if (disasm->instruction.addressValue != 0 && !(disasm->instruction.userData & DISASM_PPC_INST_LOAD_STORE)) {
                 format = Format_Address;
             }
-            else if (disasm->instruction.userData & (DISASM_PPC_INST_ADDI | DISASM_PPC_INST_SUBI | DISASM_PPC_INST_LOAD_STORE)) {
+            else if (operandIndex <= 2 &&
+                     disasm->instruction.userData & (DISASM_PPC_INST_ADDI | DISASM_PPC_INST_SUBI | DISASM_PPC_INST_LOAD_STORE)) {
                 format = Format_Hexadecimal | Format_Signed;
             }
             else {

--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -233,7 +233,11 @@ static ByteType TypeForSize(u32 size)
     // Load/store handling
     if (disasm->instruction.userData & DISASM_PPC_INST_LOAD_STORE && disasm->instruction.addressValue && disasm->operand[2].size) {
         ArgFormat format = Format_Hexadecimal;
-        if (!strncmp(disasm->instruction.mnemonic, "lf", 2) || !strncmp(disasm->instruction.mnemonic, "stf", 2))
+        if (!strcmp(disasm->instruction.mnemonic, "lwz") || !strcmp(disasm->instruction.mnemonic, "stw")) {
+            uint32_t data = [_file readInt32AtVirtualAddress:disasm->instruction.addressValue];
+            if (data >= 0x80000000 && data <= 0x8C000000)
+                format = Format_Address;
+        } else if (!strncmp(disasm->instruction.mnemonic, "lf", 2) || !strncmp(disasm->instruction.mnemonic, "stf", 2))
             format = Format_Float;
         [self addTypeToSet:disasm->instruction.addressValue size:disasm->operand[2].size format:format];
     }

--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -556,6 +556,9 @@ static int GetRegisterIndex(DisasmOperandType type)
             if (disasm->instruction.addressValue != 0 && !(disasm->instruction.userData & DISASM_PPC_INST_LOAD_STORE)) {
                 format = Format_Address;
             }
+            else if (disasm->instruction.userData & (DISASM_PPC_INST_ADDI | DISASM_PPC_INST_SUBI | DISASM_PPC_INST_LOAD_STORE)) {
+                format = Format_Hexadecimal | Format_Signed;
+            }
             else {
                 if (operand->userData[0] & DISASM_PPC_OPER_IMM_HEX || llabs(operand->immediateValue) > 255)
                     format = Format_Hexadecimal | Format_Signed;

--- a/PPCCPU/ppcd/ppcd.m
+++ b/PPCCPU/ppcd/ppcd.m
@@ -2095,7 +2095,12 @@ void PPCDisasm(PPCD_CB *discb)
         else
 #endif
         integer3("or", 'Z', ASB_A|ASB_S|ASB_B); break;           // orx
-        case 01571: integer3("or.", 'Z', ASB_A|ASB_S|ASB_B); break;
+        case 01571:
+#ifdef SIMPLIFIED
+        if (DIS_RS == DIS_RB) { integer3("mr.", 'Z', ASB_A|ASB_S); o->iclass |= PPC_DISA_SIMPLIFIED; }
+        else
+#endif
+        integer3("or.", 'Z', ASB_A|ASB_S|ASB_B); break;
         case 01626: integer3("divwu", 'X', DAB_D|DAB_A|DAB_B); break;        // divwux
         case 01626|OE: integer3("divwuo", 'X', DAB_D|DAB_A|DAB_B); break;
         case 01627: integer3("divwu.", 'X', DAB_D|DAB_A|DAB_B); break;


### PR DESCRIPTION
Yet another set of changes. This one adds the simplified `mr.` instruction. 

Also, upon the initial executable load, the user is given an additional checkbox to enable automatic address detection in the data sections. This catches common things like vtables and string arrays.