### PR TITLE
Automatic comment for optimized division by constant

### DIFF
--- a/DOL_Loader/DOLLoader.m
+++ b/DOL_Loader/DOLLoader.m
@@ -305,6 +305,7 @@ static const struct SectionRange* FindSectionRange(const struct SectionRange* ra
                         Address addr = seg.startAddress + offset;
                         [file setType:Type_Int32 atVirtualAddress:addr forLength:4];
                         [file setFormat:Format_Address forArgument:0 atVirtualAddress:addr];
+                        [seg addReferencesToAddress:data fromAddress:addr];
                     }
                 }
             }

--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -386,6 +386,26 @@ static ByteType TypeForSize(u32 size)
             if (addr != BAD_ADDRESS)
                 working.instruction.addressValue = addr + working.operand[1].immediateValue;
         }
+    } else if (working.instruction.userData & DISASM_PPC_INST_ADDI) {
+        if (working.operand[1].type & DISASM_BUILD_REGISTER_INDEX_MASK(13)) {
+            Address addr = [_file findVirtualAddressNamed:@"_SDA_BASE_"];
+            if (addr != BAD_ADDRESS)
+                working.instruction.addressValue = addr + working.operand[2].immediateValue;
+        } else if (working.operand[1].type & DISASM_BUILD_REGISTER_INDEX_MASK(2)) {
+            Address addr = [_file findVirtualAddressNamed:@"_SDA2_BASE_"];
+            if (addr != BAD_ADDRESS)
+                working.instruction.addressValue = addr + working.operand[2].immediateValue;
+        }
+    } else if (working.instruction.userData & DISASM_PPC_INST_SUBI) {
+        if (working.operand[1].type & DISASM_BUILD_REGISTER_INDEX_MASK(13)) {
+            Address addr = [_file findVirtualAddressNamed:@"_SDA_BASE_"];
+            if (addr != BAD_ADDRESS)
+                working.instruction.addressValue = addr - working.operand[2].immediateValue;
+        } else if (working.operand[1].type & DISASM_BUILD_REGISTER_INDEX_MASK(2)) {
+            Address addr = [_file findVirtualAddressNamed:@"_SDA2_BASE_"];
+            if (addr != BAD_ADDRESS)
+                working.instruction.addressValue = addr - working.operand[2].immediateValue;
+        }
     }
     
     memcpy(disasm, &working, sizeof(working));

--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -25,6 +25,8 @@ struct TypeSet {
     NSObject<HPDisassembledFile> *_file;
     bool _trackingLis;
     int32_t lisArr[32];
+    double  mulhwArr[32];
+    int32_t dividendArr[32];
     int32_t stackDisp;
     int32_t indexBaseArr[32];
     int32_t indexBaseCTR;
@@ -44,6 +46,8 @@ struct TypeSet {
         _trackingLis = false;
         for (int i = 0; i < 32; ++i) {
             lisArr[i] = ~0;
+            mulhwArr[i] = 0.0;
+            dividendArr[i] = ~0;
             indexBaseArr[i] = ~0;
         }
         indexBaseCTR = ~0;
@@ -191,7 +195,8 @@ static ByteType TypeForSize(u32 size)
             }
             else
             {
-                [_file setInlineComment:MakeNumericComment((u32)operand->userData[1]) atVirtualAddress:disasm->virtualAddr reason:CCReason_Automatic];
+                [_file setInlineComment:MakeNumericComment((u32)operand->userData[1])
+                       atVirtualAddress:disasm->virtualAddr reason:CCReason_Automatic];
             }
             
             // SDA/SDA2 symbol synthesis
@@ -200,6 +205,43 @@ static ByteType TypeForSize(u32 size)
             else if (disasm->operand[0].type & DISASM_BUILD_REGISTER_INDEX_MASK(2) && segment == _file.firstSegment)
                 foundSDA2 = (u32)operand->userData[1];
             break;
+        }
+    }
+    
+    // Handle MULHW
+    if (disasm->operand[2].userData[0] & DISASM_PPC_OPER_MULHW) {
+        int32_t divConstant = (int32_t)disasm->operand[2].userData[1];
+        if (divConstant != ~0) {
+            double factor = (double)divConstant / (double)(1LL << 32LL);
+            mulhwArr[GetRegisterIndex(disasm->operand[0].type)] = factor;
+            dividendArr[GetRegisterIndex(disasm->operand[0].type)] = GetRegisterIndex(disasm->operand[2].type);
+            double rounded = round(1.0 / factor);
+            if (fabs(rounded - 1.0 / factor) < 0.0001)
+                [_file setInlineComment:[NSString stringWithFormat:@"divide by %g", rounded]
+                       atVirtualAddress:disasm->virtualAddr reason:CCReason_Automatic];
+        }
+    } else if (!strcmp(disasm->instruction.mnemonic, "add")) {
+        int32_t dividend = dividendArr[GetRegisterIndex(disasm->operand[1].type)];
+        if (dividend == GetRegisterIndex(disasm->operand[2].type)) {
+            double factor = mulhwArr[GetRegisterIndex(disasm->operand[1].type)];
+            factor += 1.0;
+            mulhwArr[GetRegisterIndex(disasm->operand[0].type)] = factor;
+            dividendArr[GetRegisterIndex(disasm->operand[0].type)] = dividend;
+            double rounded = round(1.0 / factor);
+            if (fabs(rounded - 1.0 / factor) < 0.0001)
+                [_file setInlineComment:[NSString stringWithFormat:@"divide by %g", rounded]
+                       atVirtualAddress:disasm->virtualAddr reason:CCReason_Automatic];
+        }
+    } else if (!strcmp(disasm->instruction.mnemonic, "srawi")) {
+        int32_t dividend = dividendArr[GetRegisterIndex(disasm->operand[1].type)];
+        if (dividend != ~0) {
+            double factor = mulhwArr[GetRegisterIndex(disasm->operand[1].type)];
+            factor /= (double)(1LL << disasm->operand[2].immediateValue);
+            mulhwArr[GetRegisterIndex(disasm->operand[0].type)] = factor;
+            double rounded = round(1.0 / factor);
+            if (fabs(rounded - 1.0 / factor) < 0.0001)
+                [_file setInlineComment:[NSString stringWithFormat:@"divide by %g", rounded]
+                       atVirtualAddress:disasm->virtualAddr reason:CCReason_Automatic];
         }
     }
     
@@ -276,6 +318,8 @@ static ByteType TypeForSize(u32 size)
     _trackingLis = false;
     for (int i = 0; i < 32; ++i) {
         lisArr[i] = ~0;
+        mulhwArr[i] = 0.0;
+        dividendArr[i] = ~0;
         indexBaseArr[i] = ~0;
     }
     lastCmplwi = 0;

--- a/PPCCPU/ppcd/CommonDefs.h
+++ b/PPCCPU/ppcd/CommonDefs.h
@@ -55,6 +55,7 @@ HP_END_DECL_ENUM(PPCIncrement);
 #define DISASM_PPC_OPER_IMM_HEX 0x1
 #define DISASM_PPC_OPER_LIS_ADDI 0x2
 #define DISASM_PPC_OPER_RLWIMI 0x4
+#define DISASM_PPC_OPER_MULHW 0x8
 
 static inline u32 MASK32VAL(u32 b, u32 e)
 {

--- a/PPCCPU/ppcd/ppcd.m
+++ b/PPCCPU/ppcd/ppcd.m
@@ -500,7 +500,7 @@ static void integer(const char *mnem, char form, int dab, int hex, int s, int cr
     else if(form == 'S')
     {
         s32 thisLis = ~0;
-        if (o->lisArr && !strcmp(mnem, "ori"))
+        if (o->lisArr && !strncmp(mnem, "ori", 3))
             thisLis = o->lisArr[DIS_RS];
             
         if(dab & ASB_A)
@@ -532,6 +532,10 @@ static void integer(const char *mnem, char form, int dab, int hex, int s, int cr
     }
     else if(form == 'X')    // DAB
     {
+        s32 thisLis = ~0;
+        if (o->lisArr && !strncmp(mnem, "mulhw", 5))
+            thisLis = o->lisArr[DIS_RA];
+        
         if(dab & DAB_D)
         {
             ptr += sprintf(ptr, "%s", REGD);
@@ -548,6 +552,13 @@ static void integer(const char *mnem, char form, int dab, int hex, int s, int cr
             if(dab & (DAB_D|DAB_A)) ptr += sprintf(ptr, "%s", COMMA);
             ptr += sprintf(ptr, "%s", REGB);
             DISASM_PPC_BUILD_GPR_OP(rb, false);
+        }
+        
+        if (thisLis != ~0)
+        {
+            DisasmOperand* op = &o->disasm->operand[o->opIdx-1];
+            op->userData[0] |= DISASM_PPC_OPER_MULHW;
+            op->userData[1] = thisLis;
         }
     }
     else if(form == 'F')    // FPU DAB


### PR DESCRIPTION
This feature adds special commenting for `mulhw` and subsequent `add` and `srawi` instructions. `mulhw` is typically used to implement division by constant semantics. This works by multiplying an integer by a magic constant and shifting it right a specified number of bits to simulate an otherwise expensive division instruction.

Any detected division by constants are commented with `divide by X`.

![](https://cdn.discordapp.com/attachments/266413691287765004/424446210783313921/unknown.png)

The technique is explained more here:
http://www.hackersdelight.org/divcMore.pdf