### PR TITLE
Add RELLinker tool for importing REL binaries

### DIFF
--- a/DOL_Loader/DOLLoader.m
+++ b/DOL_Loader/DOLLoader.m
@@ -255,6 +255,7 @@ static const struct SectionRange* FindSectionRange(const struct SectionRange* ra
     bssLength = range->length;
     if(bssLocation >= 0x80000000 && bssLocation <= 0x8C000000 && bssLength > 0){
         NSObject<HPSegment> *segment = [file addSegmentAt:bssLocation size:bssLength];
+        [segment setMappedData:[NSMutableData dataWithLength:bssLength]];
         NSObject<HPSection> *section = [segment addSectionAt:bssLocation size:bssLength];
         segment.segmentName = @"BSS";
         section.sectionName = @"bss";
@@ -276,6 +277,7 @@ static const struct SectionRange* FindSectionRange(const struct SectionRange* ra
             uint32_t sbssLocation = range1->start + range1->length;
             uint32_t sbssLength = range2->start - sbssLocation;
             NSObject<HPSegment> *segment = [file addSegmentAt:sbssLocation size:sbssLength];
+            [segment setMappedData:[NSMutableData dataWithLength:sbssLength]];
             NSObject<HPSection> *section = [segment addSectionAt:sbssLocation size:sbssLength];
             segment.segmentName = @"SBSS";
             section.sectionName = @"sbss";

--- a/DOL_Loader/DOLLoader.m
+++ b/DOL_Loader/DOLLoader.m
@@ -11,15 +11,15 @@
 #ifdef LINUX
 #include <endian.h>
 
-int16_t OSReadBigInt16(const void *address, uintptr_t offset) {
+static int16_t OSReadBigInt16(const void *address, uintptr_t offset) {
     return be16toh(*(int16_t *) ((uintptr_t) address + offset));
 }
 
-int32_t OSReadBigInt32(const void *address, uintptr_t offset) {
+static int32_t OSReadBigInt32(const void *address, uintptr_t offset) {
     return be32toh(*(int32_t *) ((uintptr_t) address + offset));
 }
 
-void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
+static void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
     *(int32_t *) ((uintptr_t) address + offset) = htobe32(data);
 }
 

--- a/DOL_Loader/DOLLoader.m
+++ b/DOL_Loader/DOLLoader.m
@@ -365,16 +365,18 @@ static const struct SectionRange* FindSectionRange(const struct SectionRange* ra
         } else if (!strcmp(type, "WSTR")) {
             [file setType:Type_Unicode atVirtualAddress:address forLength:arrCount];
         } else if (!strcmp(type, "BYTE")) {
-            [file setType:Type_Int8 atVirtualAddress:address forLength:arrCount ? arrCount : 1];
+            [file setType:Type_Int8 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 1];
         } else if (!strcmp(type, "WORD")) {
-            [file setType:Type_Int16 atVirtualAddress:address forLength:arrCount ? arrCount : 2];
+            [file setType:Type_Int16 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 2];
         } else if (!strcmp(type, "DWORD")) {
-            [file setType:Type_Int32 atVirtualAddress:address forLength:arrCount ? arrCount : 4];
+            [file setType:Type_Int32 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 4];
+        } else if (!strcmp(type, "QWORD")) {
+            [file setType:Type_Int64 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 8];
         } else if (!strcmp(type, "FLOAT")) {
-            [file setType:Type_Int32 atVirtualAddress:address forLength:arrCount ? arrCount : 4];
+            [file setType:Type_Int32 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 4];
             [file setFormat:Format_Float forArgument:0 atVirtualAddress:address];
         } else if (!strcmp(type, "DOUBLE")) {
-            [file setType:Type_Int64 atVirtualAddress:address forLength:arrCount ? arrCount : 8];
+            [file setType:Type_Int64 atVirtualAddress:address forLength:(arrCount ? arrCount : 1) * 8];
             [file setFormat:Format_Float forArgument:0 atVirtualAddress:address];
         } else if (!strcmp(type, "LVAR")) {
             NSObject<HPProcedure> *proc = [file procedureAt:address];

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,13 +2,16 @@ include $(GNUSTEP_MAKEFILES)/common.make
 
 COMMON_OBJC_FLAGS = -I../include -DLINUX -Wno-format -fblocks -fobjc-nonfragile-abi -fobjc-arc
 
-BUNDLE_NAME = PPCCPU DOL_Loader
+BUNDLE_NAME = PPCCPU DOL_Loader REL_Linker
 
 PPCCPU_OBJC_FILES = PPCCPU/PPCCPU.m PPCCPU/PPCCtx.m PPCCPU/ppcd/ppcd.m
 PPCCPU_OBJCFLAGS=$(COMMON_OBJC_FLAGS)
 
 DOL_Loader_OBJC_FILES = DOL_Loader/DOLLoader.m
 DOL_Loader_OBJCFLAGS=$(COMMON_OBJC_FLAGS)
+
+REL_Linker_OBJC_FILES = REL_Linker/RELLinker.m
+REL_Linker_OBJCFLAGS=$(COMMON_OBJC_FLAGS)
 
 include $(GNUSTEP_MAKEFILES)/bundle.make
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 include $(GNUSTEP_MAKEFILES)/common.make
 
-COMMON_OBJC_FLAGS = -I../include -DLINUX -Wno-format -fblocks -fobjc-nonfragile-abi -fobjc-arc
+COMMON_OBJC_FLAGS = -I../include -DLINUX -Wno-format -fblocks -fobjc-nonfragile-abi -fobjc-arc -O3
 
 BUNDLE_NAME = PPCCPU DOL_Loader REL_Linker
 

--- a/PPCCPU/PPCCPU.m
+++ b/PPCCPU/PPCCPU.m
@@ -12,15 +12,15 @@
 #ifdef LINUX
 #include <endian.h>
 
-int16_t OSReadBigInt16(const void *address, uintptr_t offset) {
+static int16_t OSReadBigInt16(const void *address, uintptr_t offset) {
     return be16toh(*(int16_t *) ((uintptr_t) address + offset));
 }
 
-int32_t OSReadBigInt32(const void *address, uintptr_t offset) {
+static int32_t OSReadBigInt32(const void *address, uintptr_t offset) {
     return be32toh(*(int32_t *) ((uintptr_t) address + offset));
 }
 
-void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
+static void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
     *(int32_t *) ((uintptr_t) address + offset) = htobe32(data);
 }
 

--- a/PPCCPU/PPCCPU.m
+++ b/PPCCPU/PPCCPU.m
@@ -9,6 +9,23 @@
 #import "PPCCPU.h"
 #import "PPCCtx.h"
 
+#ifdef LINUX
+#include <endian.h>
+
+int16_t OSReadBigInt16(const void *address, uintptr_t offset) {
+    return be16toh(*(int16_t *) ((uintptr_t) address + offset));
+}
+
+int32_t OSReadBigInt32(const void *address, uintptr_t offset) {
+    return be32toh(*(int32_t *) ((uintptr_t) address + offset));
+}
+
+void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
+    *(int32_t *) ((uintptr_t) address + offset) = htobe32(data);
+}
+
+#endif
+
 @implementation PPCCPU {
     NSObject<HPHopperServices> *_services;
 }

--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -273,7 +273,8 @@ static ByteType TypeForSize(u32 size)
     }
     
     // Load/store handling
-    if (disasm->instruction.userData & DISASM_PPC_INST_LOAD_STORE && disasm->instruction.addressValue && disasm->operand[2].size) {
+    if (disasm->instruction.userData & DISASM_PPC_INST_LOAD_STORE &&
+        disasm->instruction.addressValue && disasm->operand[2].size) {
         ArgFormat format = Format_Hexadecimal;
         if (!strcmp(disasm->instruction.mnemonic, "lwz") || !strcmp(disasm->instruction.mnemonic, "stw")) {
             uint32_t data = [_file readInt32AtVirtualAddress:disasm->instruction.addressValue];

--- a/PPCCPU/ppcd/ppcd.m
+++ b/PPCCPU/ppcd/ppcd.m
@@ -1921,7 +1921,9 @@ void PPCDisasm(PPCD_CB *discb)
         case 00301: crop3("xor", "clr", 1); break;                           // crxor
         case 00226: put2("isync", 0x3fff801); break;                         // isync
 #ifdef  POWERPC_32
-        case 00062: put("rfi", 0x3fff801, 0, PPC_DISA_OEA | PPC_DISA_BRIDGE ); break; // rfi
+        case 00062: put("rfi", 0x3fff801, 0, PPC_DISA_OEA | PPC_DISA_BRIDGE );
+            o->disasm->instruction.branchType = DISASM_BRANCH_RET;
+            break; // rfi
 #endif
 #ifdef  POWERPC_64
         case 00022: put("rfid", 0x3fff801, 0, PPC_DISA_OEA | PPC_DISA_64 ); break; // rfid

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The license for that is listed as "free opensource". This is too.
 The DOL loading code is original, but the file format is very simple.
 
 # macOS install
-1. Checkout or download this repository into a subfolder of your Hopper SDK download so the XCode project can find the includes.
-2. Open the XCode Project.
-3. Build the XCode Project.
-4. That's it. Building the project will install it into the plugins directory.
+1. Checkout or download this repository into a subfolder of your Hopper SDK download so the XCode projects can find the includes.
+2. Open each XCode Project.
+3. Build each XCode Project.
+4. That's it. Building the plugins will install them into the plugins directory.
 
 # Linux install
 1. Checkout or download this repository into a subfolder of your Hopper SDK download.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ This repository contains a plugin for Hopper Disassembler called DOLLoader which
 
 ![metroid prime switch statement](https://jackoalan.github.io/HopperPPC-Plugin/MetroidPrimeSwitchStatement.png "A switch statement from Metroid Prime")
 
-# HopperPPC-Plugin
+# PPCCPU Plugin
 The repository also contains a plugin which adds support for the Gecko variant of the IBM PowerPC 750. This CPU reports itself as `ppc32/gecko` and will only work with 32-bit PPC binaries. In addition to supporting Gecko instructions, linker-defined symbols left for the CodeWarrior C runtime are automatically discovered and used to aid in resolving SDA memory accesses via `r13` and `r2`. Sections are named according to the GameCube's common linker configuration (init, extab, text, data, rodata, sdata, sdata2, etc). The PPC plugin also performs inline stack variable printing for load/store/addi instructions relative to `r1`.
+
+# REL Linker
+The repository also contains a tool which links REL files appended to the DOL within Hopper. To use this, open one or more REL files (shipped with the DOL) using File > Load Additional Binary. You have the option to specify where in virtual memory the REL gets mapped. Hopper's default value is typically fine; but make sure it's 32-byte aligned. The other options may be left at their defaults. Next, run the linker from Tool Plugins > Link REL Segments. When this completes, you may browse the new sections using Navigate > Show Section List...
 
 # Acknowledgements
 Both plugins originally thrown together by Paul Kratt.
@@ -15,9 +18,11 @@ Forked by Jack Andersen and fleshed out with the following:
 - Proper syntax-colored operands
 - Instruction simplifications for `rlwinm` (slwi, clrlwi, extlwi, etc)
 - Automatic comments rendering `rlwinm` as a C expression
+- Automatic comments for division by constant
 - Inline stack variables
 - Jump table parsing and case label generation
 - Section names and permissions based on the GameCube's CodeWarrior toolchain
+- REL Linking
 - Linux makefile
 
 See commit history for other contributions.
@@ -44,4 +49,5 @@ The DOL loading code is original, but the file format is very simple.
 mkdir -p ~/GNUstep/Library/ApplicationSupport/Hopper/PlugIns/v4/{CPUs,Loaders,Tools}
 ln -s $(pwd)/PPCCPU.bundle ~/GNUstep/Library/ApplicationSupport/Hopper/PlugIns/v4/CPUs/PPCCPU.hopperCPU
 ln -s $(pwd)/DOL_Loader.bundle ~/GNUstep/Library/ApplicationSupport/Hopper/PlugIns/v4/Loaders/DOL_Loader.hopperLoader
+ln -s $(pwd)/REL_Linker.bundle ~/GNUstep/Library/ApplicationSupport/Hopper/PlugIns/v4/Tools/REL_Linker.hopperTool
 ```

--- a/RELLinker.xcodeproj/project.pbxproj
+++ b/RELLinker.xcodeproj/project.pbxproj
@@ -1,0 +1,339 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		07AC766718C8CB9A007D5414 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07AC766618C8CB9A007D5414 /* CoreFoundation.framework */; };
+		07AC766D18C8CB9A007D5414 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 07AC766B18C8CB9A007D5414 /* InfoPlist.strings */; };
+		07AC767618C8CBC8007D5414 /* RELLinker.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AC767518C8CBC8007D5414 /* RELLinker.m */; };
+		07AC767918C8CED6007D5414 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07AC767818C8CED6007D5414 /* Cocoa.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		07AC766318C8CB9A007D5414 /* RELLinker.hopperTool */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RELLinker.hopperTool; sourceTree = BUILT_PRODUCTS_DIR; };
+		07AC766618C8CB9A007D5414 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		07AC766A18C8CB9A007D5414 /* RELLinker-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RELLinker-Info.plist"; sourceTree = "<group>"; };
+		07AC766C18C8CB9A007D5414 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		07AC766E18C8CB9A007D5414 /* RELLinker-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RELLinker-Prefix.pch"; sourceTree = "<group>"; };
+		07AC767418C8CBC8007D5414 /* RELLinker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RELLinker.h; sourceTree = "<group>"; };
+		07AC767518C8CBC8007D5414 /* RELLinker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RELLinker.m; sourceTree = "<group>"; };
+		07AC767818C8CED6007D5414 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		07AC766018C8CB9A007D5414 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				07AC767918C8CED6007D5414 /* Cocoa.framework in Frameworks */,
+				07AC766718C8CB9A007D5414 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		07AC765A18C8CB9A007D5414 = {
+			isa = PBXGroup;
+			children = (
+				07AC766818C8CB9A007D5414 /* RELLinker */,
+				07AC766918C8CB9A007D5414 /* Supporting Files */,
+				07AC766518C8CB9A007D5414 /* Frameworks */,
+				07AC766418C8CB9A007D5414 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		07AC766418C8CB9A007D5414 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				07AC766318C8CB9A007D5414 /* RELLinker.hopperTool */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		07AC766518C8CB9A007D5414 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				07AC767818C8CED6007D5414 /* Cocoa.framework */,
+				07AC766618C8CB9A007D5414 /* CoreFoundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		07AC766818C8CB9A007D5414 /* RELLinker */ = {
+			isa = PBXGroup;
+			children = (
+				07AC767418C8CBC8007D5414 /* RELLinker.h */,
+				07AC767518C8CBC8007D5414 /* RELLinker.m */,
+			);
+			name = RELLinker;
+			path = REL_Linker;
+			sourceTree = "<group>";
+		};
+		07AC766918C8CB9A007D5414 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				07AC766A18C8CB9A007D5414 /* RELLinker-Info.plist */,
+				07AC766B18C8CB9A007D5414 /* InfoPlist.strings */,
+				07AC766E18C8CB9A007D5414 /* RELLinker-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			path = REL_Linker;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		07AC766218C8CB9A007D5414 /* RELLinker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 07AC767118C8CB9A007D5414 /* Build configuration list for PBXNativeTarget "RELLinker" */;
+			buildPhases = (
+				07AC765F18C8CB9A007D5414 /* Sources */,
+				07AC766018C8CB9A007D5414 /* Frameworks */,
+				07AC766118C8CB9A007D5414 /* Resources */,
+				07AC767718C8CBF4007D5414 /* Run Script (Installation) */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RELLinker;
+			productName = SampleTool;
+			productReference = 07AC766318C8CB9A007D5414 /* RELLinker.hopperTool */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		07AC765B18C8CB9A007D5414 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				ORGANIZATIONNAME = "Cryptic Apps";
+			};
+			buildConfigurationList = 07AC765E18C8CB9A007D5414 /* Build configuration list for PBXProject "RELLinker" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 07AC765A18C8CB9A007D5414;
+			productRefGroup = 07AC766418C8CB9A007D5414 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				07AC766218C8CB9A007D5414 /* RELLinker */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		07AC766118C8CB9A007D5414 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				07AC766D18C8CB9A007D5414 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		07AC767718C8CBF4007D5414 /* Run Script (Installation) */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script (Installation)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"${INSTALL_PATH}/RELLinker.hopperTool\"\nmkdir -p \"${INSTALL_PATH}\"\ncp -rf \"${BUILT_PRODUCTS_DIR}/RELLinker.hopperTool\" \"${INSTALL_PATH}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		07AC765F18C8CB9A007D5414 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				07AC767618C8CBC8007D5414 /* RELLinker.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		07AC766B18C8CB9A007D5414 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				07AC766C18C8CB9A007D5414 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		07AC766F18C8CB9A007D5414 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		07AC767018C8CB9A007D5414 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		07AC767218C8CB9A007D5414 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "REL_Linker/RELLinker-prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../include",
+				);
+				INFOPLIST_FILE = "REL_Linker/RELLinker-Info.plist";
+				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/v4/Tools";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cryptic-apps.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = hopperTool;
+			};
+			name = Debug;
+		};
+		07AC767318C8CB9A007D5414 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "REL_Linker/RELLinker-prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../include",
+				);
+				INFOPLIST_FILE = "REL_Linker/RELLinker-Info.plist";
+				INSTALL_PATH = "$(USER_LIBRARY_DIR)/Application Support/Hopper/PlugIns/v4/Tools";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cryptic-apps.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = hopperTool;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		07AC765E18C8CB9A007D5414 /* Build configuration list for PBXProject "RELLinker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				07AC766F18C8CB9A007D5414 /* Debug */,
+				07AC767018C8CB9A007D5414 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		07AC767118C8CB9A007D5414 /* Build configuration list for PBXNativeTarget "RELLinker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				07AC767218C8CB9A007D5414 /* Debug */,
+				07AC767318C8CB9A007D5414 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 07AC765B18C8CB9A007D5414 /* Project object */;
+}

--- a/RELLinker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RELLinker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/jacko/Downloads/HopperSDK-4.3.16/HopperPPC-Plugin/RELLinker.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/REL_Linker/RELLinker-Info.plist
+++ b/REL_Linker/RELLinker-Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFPlugInDynamicRegisterFunction</key>
+	<string></string>
+	<key>CFPlugInDynamicRegistration</key>
+	<string>NO</string>
+	<key>CFPlugInFactories</key>
+	<dict>
+		<key>00000000-0000-0000-0000-000000000000</key>
+		<string>MyFactoryFunction</string>
+	</dict>
+	<key>CFPlugInTypes</key>
+	<dict>
+		<key>00000000-0000-0000-0000-000000000000</key>
+		<array>
+			<string>00000000-0000-0000-0000-000000000000</string>
+		</array>
+	</dict>
+	<key>CFPlugInUnloadFunction</key>
+	<string></string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2018 Jack Andersen. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string>RELLinker</string>
+</dict>
+</plist>

--- a/REL_Linker/RELLinker-Prefix.pch
+++ b/REL_Linker/RELLinker-Prefix.pch
@@ -1,0 +1,9 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/REL_Linker/RELLinker.h
+++ b/REL_Linker/RELLinker.h
@@ -1,9 +1,9 @@
 //
-//  SampleTool.h
-//  SampleTool
+//  RELLinker.h
+//  RELLinker
 //
-//  Created by Vincent Bénony on 06/03/2014.
-//  Copyright (c) 2014 Cryptic Apps. All rights reserved.
+//  Created by Jack Andersen on 18/03/2018.
+//  Copyright (c) 2018 Jack Andersen. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/REL_Linker/RELLinker.h
+++ b/REL_Linker/RELLinker.h
@@ -1,0 +1,14 @@
+//
+//  SampleTool.h
+//  SampleTool
+//
+//  Created by Vincent Bénony on 06/03/2014.
+//  Copyright (c) 2014 Cryptic Apps. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Hopper/HopperTool.h>
+
+@interface RELLinker : NSObject<HopperTool>
+
+@end

--- a/REL_Linker/RELLinker.m
+++ b/REL_Linker/RELLinker.m
@@ -2,8 +2,8 @@
 //  RELLinker.m
 //  RELLinker
 //
-//  Created by Vincent Bénony on 06/03/2014.
-//  Copyright (c) 2014 Cryptic Apps. All rights reserved.
+//  Created by Jack Andersen on 18/03/2018.
+//  Copyright (c) 2018 Jack Andersen. All rights reserved.
 //
 
 #import "RELLinker.h"
@@ -133,8 +133,7 @@ struct rel_relocation_entry
 
 - (void)_prelinkREL:(NSObject<HPSegment>*)segment file:(NSObject<HPDisassembledFile>*)file {
     [_services.currentDocument beginToWait:@"Pre-Linking REL"];
-    NSMutableData* mutable = [segment.mappedData mutableCopy];
-    void *bytes = mutable.mutableBytes;
+    const void *bytes = segment.mappedData.bytes;
     
     // Initial metadata
     segment.readable = YES;

--- a/REL_Linker/RELLinker.m
+++ b/REL_Linker/RELLinker.m
@@ -412,15 +412,16 @@ struct rel_relocation_entry
     for (NSObject<HPSegment> *seg in doc.disassembledFile.segments) {
         if ([seg.segmentName isEqualToString:@"unnamed segment"]) {
             const void *bytes = seg.mappedData.bytes;
-            uint32_t module_id = OSReadBigInt32(bytes, 0);
-            if (module_id == 0 || OSReadBigInt32(bytes, 4) != 0 || OSReadBigInt32(bytes, 8) != 0)
+            const struct relhdr *header = bytes;
+            uint32_t module_id = _bswap32(header->info.module_id);
+            if (module_id == 0 || _bswap32(header->info.prev) != 0 || _bswap32(header->info.next) != 0)
                 continue;
-            uint32_t version = OSReadBigInt32(bytes, 28);
+            uint32_t version = _bswap32(header->info.version);
             if (version != 1 && version != 2 && version != 3)
                 continue;
             
-            uint32_t sectionInfoOff = OSReadBigInt32(bytes, 16);
-            uint32_t importTableOff = OSReadBigInt32(bytes, 40);
+            uint32_t sectionInfoOff = _bswap32(header->info.section_offset);
+            uint32_t importTableOff = _bswap32(header->import_offset);
             if (sectionInfoOff >= seg.mappedData.length || importTableOff >= seg.mappedData.length)
                 continue;
             

--- a/REL_Linker/RELLinker.m
+++ b/REL_Linker/RELLinker.m
@@ -1,0 +1,490 @@
+//
+//  RELLinker.m
+//  RELLinker
+//
+//  Created by Vincent Bénony on 06/03/2014.
+//  Copyright (c) 2014 Cryptic Apps. All rights reserved.
+//
+
+#import "RELLinker.h"
+#import <Hopper/HPHopperServices.h>
+#import <Hopper/HPDocument.h>
+#import <Hopper/HPDisassembledFile.h>
+#import <Hopper/HPSegment.h>
+#import <Hopper/HPSection.h>
+#import <Hopper/HPProcedure.h>
+#import <Hopper/HPBasicBlock.h>
+#import <Hopper/HPCallReference.h>
+#import <Hopper/CPUContext.h>
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+static inline int16_t _bswap16(int16_t v) {
+    return __builtin_bswap16(v);
+}
+static inline int32_t _bswap32(int32_t v) {
+    return __builtin_bswap32(v);
+}
+#else
+static inline int16_t _bswap16(int16_t v) {
+    return v;
+}
+static inline int32_t _bswap32(int32_t v) {
+    return v;
+}
+#endif
+
+struct relhdr_info
+{
+    uint32_t module_id;          // in .rso or .rel, not in .sel
+    
+    // in .rso or .rel or .sel
+    uint32_t prev;
+    uint32_t next;
+    uint32_t num_sections;
+    uint32_t section_offset;    // points to section_entry*
+    uint32_t name_offset;
+    uint32_t name_size;
+    uint32_t version;
+};
+
+struct relhdr
+{
+    struct relhdr_info info;
+    
+    // version 1
+    uint32_t bss_size;
+    uint32_t rel_offset;
+    uint32_t import_offset;
+    uint32_t import_size;         // size in bytes
+    
+    // Section ids containing functions
+    uint8_t prolog_section;
+    uint8_t epilog_section;
+    uint8_t unresolved_section;
+    uint8_t bss_section;
+    
+    uint32_t prolog_offset;
+    uint32_t epilog_offset;
+    uint32_t unresolved_offset;
+    
+    // version 2
+    uint32_t align;
+    uint32_t bss_align;
+    
+    // version 3
+    uint32_t fix_size;
+};
+
+struct rel_section_entry
+{
+    uint32_t file_offset;
+    uint32_t size;
+};
+
+struct rel_import_entry
+{
+    uint32_t module_id;      // module id, maps to id in relhdr_info, 0 = base application
+    uint32_t offset;
+};
+
+enum PPCRelocationType
+{
+    R_PPC_NONE,
+    R_PPC_ADDR32,
+    R_PPC_ADDR24,
+    R_PPC_ADDR16,
+    R_PPC_ADDR16_LO,
+    R_PPC_ADDR16_HI,
+    R_PPC_ADDR16_HA,
+    R_PPC_ADDR14,
+    R_PPC_ADDR14_BRTAKEN,
+    R_PPC_ADDR14_BRNTAKEN,
+    R_PPC_REL24,
+    R_PPC_REL14,
+    R_DOLPHIN_NOP = 201,
+    R_DOLPHIN_SECTION = 202,
+    R_DOLPHIN_END = 203
+};
+
+struct rel_relocation_entry
+{
+    uint16_t advancement;
+    uint8_t type;
+    uint8_t section;
+    uint32_t offset;
+};
+
+@implementation RELLinker {
+    NSObject<HPHopperServices> *_services;
+}
+
+- (NSArray *)toolMenuDescription {
+    return @[
+             @{HPM_TITLE: @"Link REL Segments",
+               HPM_SELECTOR: @"linkREL:"},
+             ];
+}
+
+- (void)_prelinkREL:(NSObject<HPSegment>*)segment file:(NSObject<HPDisassembledFile>*)file {
+    [_services.currentDocument beginToWait:@"Pre-Linking REL"];
+    NSMutableData* mutable = [segment.mappedData mutableCopy];
+    void *bytes = mutable.mutableBytes;
+    
+    // Initial metadata
+    segment.readable = YES;
+    segment.writable = YES;
+    segment.executable = YES;
+    const struct relhdr *header = bytes;
+    uint32_t moduleId = _bswap32(header->info.module_id);
+    uint32_t version = _bswap32(header->info.version);
+    uint32_t bssAlign = 32;
+    if (version >= 2)
+        bssAlign = _bswap32(header->bss_align);
+    uint32_t bssSize = _bswap32(header->bss_size);
+    segment.segmentName = [NSString stringWithFormat:@"REL%u", moduleId];
+
+    // BSS starts here
+    NSUInteger bssStart = (file.lastSegment.endAddress + bssAlign - 1) / bssAlign * bssAlign;
+
+    // Advertize REL sections to Hopper
+    const struct rel_section_entry *sections = bytes + _bswap32(header->info.section_offset);
+    uint32_t numSections = _bswap32(header->info.num_sections);
+    for (int i = 0; i < numSections; ++i) {
+        const struct rel_section_entry *section = &sections[i];
+        uint32_t fileOffset = _bswap32(section->file_offset);
+        uint32_t sectionSize = _bswap32(section->size);
+        if (fileOffset == 0 && sectionSize == bssSize) {
+            if (bssSize == 0)
+                continue;
+            NSObject<HPSegment> *seg = [file addSegmentAt:bssStart size:bssSize];
+            seg.readable = YES;
+            seg.writable = YES;
+            seg.executable = NO;
+            [seg setMappedData:[NSMutableData dataWithLength:bssSize]];
+            seg.segmentName = [NSString stringWithFormat:@"BSS%u", moduleId];
+            NSObject<HPSection> *sec = [seg addSectionAt:bssStart size:bssSize];
+            sec.sectionName = [NSString stringWithFormat:@"bss%u", moduleId];
+            sec.zeroFillSection = YES;
+        } else if (sectionSize != 0) {
+            NSObject<HPSection> *sec = [segment addSectionAt:segment.startAddress + (fileOffset & 0xfffffffe) size:sectionSize];
+            if (fileOffset & 0x1) {
+                sec.pureCodeSection = YES;
+                sec.containsCode = YES;
+                sec.sectionName = [NSString stringWithFormat:@"text%u_%u", moduleId, i];
+            } else {
+                sec.pureDataSection = YES;
+                sec.sectionName = [NSString stringWithFormat:@"data%u_%u", moduleId, i];
+            }
+        }
+    }
+    
+    [_services.currentDocument endWaiting];
+}
+
+- (void)recursiveMakeProcedures:(NSObject<HPProcedure>*)proc file:(NSObject<HPDisassembledFile>*)file {
+    if (!proc)
+        return;
+    for (NSObject<HPCallReference> *cref in proc.allCallees) {
+        if (![file hasProcedureAt:cref.to])
+            [self recursiveMakeProcedures:[file makeProcedureAt:cref.to] file:file];
+    }
+}
+
+- (void)_linkREL:(NSObject<HPSegment>*)segment file:(NSObject<HPDisassembledFile>*)file {
+    [_services.currentDocument beginToWait:@"Linking REL"];
+    NSMutableData* mutable = [segment.mappedData mutableCopy];
+    void *bytes = mutable.mutableBytes;
+    
+    // Initial metadata
+    const struct relhdr *header = bytes;
+    uint32_t moduleId = _bswap32(header->info.module_id);
+    uint32_t version = _bswap32(header->info.version);
+    uint32_t bssAlign = 32;
+    if (version >= 2)
+        bssAlign = _bswap32(header->bss_align);
+    uint32_t bssSize = _bswap32(header->bss_size);
+    
+    // Advertize REL sections to Hopper
+    const struct rel_section_entry *sections = bytes + _bswap32(header->info.section_offset);
+    uint32_t numSections = _bswap32(header->info.num_sections);
+    NSMutableArray *textSections = [NSMutableArray arrayWithCapacity:4];
+    NSMutableArray *dataSections = [NSMutableArray arrayWithCapacity:8];
+    for (int i = 0; i < numSections; ++i) {
+        const struct rel_section_entry *section = &sections[i];
+        uint32_t fileOffset = _bswap32(section->file_offset);
+        uint32_t sectionSize = _bswap32(section->size);
+        if (fileOffset == 0 && sectionSize == bssSize) {
+        } else if (sectionSize != 0) {
+            NSObject<HPSection> *sec = [file sectionForVirtualAddress:segment.startAddress + (fileOffset & 0xfffffffe)];
+            if (fileOffset & 0x1)
+                [textSections addObject:sec];
+            else
+                [dataSections addObject:sec];
+        }
+    }
+    
+    // Enumerate imports and relocations
+    const struct rel_import_entry *imports = bytes + _bswap32(header->import_offset);
+    uint32_t numImports = _bswap32(header->import_size) / 8;
+    for (int i = 0; i < numImports; ++i) {
+        const struct rel_import_entry *import = &imports[i];
+        uint32_t moduleId = _bswap32(import->module_id);
+        NSObject<HPSegment> *moduleSeg = nil;
+        NSObject<HPSegment> *moduleBss = nil;
+        const struct rel_section_entry *moduleSections = NULL;
+        if (moduleId) {
+            moduleSeg = [file segmentNamed:[NSString stringWithFormat:@"REL%u", moduleId]];
+            moduleBss = [file segmentNamed:[NSString stringWithFormat:@"BSS%u", moduleId]];
+            if (moduleSeg) {
+                const void *moduleBytes = moduleSeg.mappedData.bytes;
+                const struct relhdr *moduleHeader = moduleBytes;
+                moduleSections = moduleBytes + _bswap32(moduleHeader->info.section_offset);
+            }
+        }
+        const struct rel_relocation_entry *relocation = bytes + _bswap32(import->offset);
+        void *codePtr = NULL;
+        for (bool done = false; !done; ++relocation) {
+            uint16_t advancement = _bswap16(relocation->advancement);
+            uint32_t offset = _bswap32(relocation->offset);
+            if (moduleSeg) {
+                const struct rel_section_entry *modSec = &moduleSections[relocation->section];
+                uint32_t fileOffset = _bswap32(modSec->file_offset);
+                if (!fileOffset)
+                    offset += moduleBss.startAddress;
+                else
+                    offset += moduleSeg.startAddress + (fileOffset & 0xfffffffe);
+            }
+            codePtr += advancement;
+            Address thisAddr = segment.startAddress + (codePtr - bytes);
+            [[_services currentDocument] logInfoMessage:[NSString stringWithFormat:@"RELOC %08X %d %08X", (uint32_t)thisAddr, relocation->type, offset]];
+            switch (relocation->type) {
+            default:
+                break;
+            case R_PPC_ADDR32:
+                *(uint32_t*)codePtr = _bswap32(offset);
+                break;
+            case R_PPC_ADDR24: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFC000003;
+                inst |= offset & 0x3FFFFFC;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_PPC_ADDR16:
+                *(uint16_t*)codePtr = _bswap16((uint16_t)offset);
+                break;
+            case R_PPC_ADDR16_LO:
+                *(uint16_t*)codePtr = _bswap16((uint16_t)offset);
+                break;
+            case R_PPC_ADDR16_HI:
+                *(uint16_t*)codePtr = _bswap16((uint16_t)(offset >> 16));
+                break;
+            case R_PPC_ADDR16_HA:
+                if (offset & 0x8000)
+                    *(uint16_t*)codePtr = _bswap16((uint16_t)((offset >> 16) + 1));
+                else
+                    *(uint16_t*)codePtr = _bswap16((uint16_t)(offset >> 16));
+                break;
+            case R_PPC_ADDR14: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFFFF0003;
+                inst |= offset & 0xFFFC;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_PPC_ADDR14_BRTAKEN: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFFDF0003;
+                inst |= (offset & 0xFFFC) | 0x200000;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_PPC_ADDR14_BRNTAKEN: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFFDF0003;
+                inst |= offset & 0xFFFC;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_PPC_REL24: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFC000003;
+                inst |= ((int64_t)offset - (int64_t)thisAddr) & 0x3FFFFFC;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_PPC_REL14: {
+                uint32_t inst = _bswap32(*(uint32_t*)codePtr);
+                inst &= 0xFFFF0003;
+                inst |= ((int64_t)offset - (int64_t)thisAddr) & 0xFFFC;
+                *(uint32_t*)codePtr = _bswap32(inst);
+                break;
+            }
+            case R_DOLPHIN_SECTION: {
+                const struct rel_section_entry *section = &sections[relocation->section];
+                uint32_t fileOffset = _bswap32(section->file_offset);
+                codePtr = bytes + (fileOffset & 0xfffffffe);
+                break;
+            }
+            case R_DOLPHIN_END:
+                done = true;
+                break;
+            }
+        }
+    }
+    
+    // Apply relocated data
+    [segment setMappedData:mutable];
+    
+    // Prolog
+    if (header->prolog_section) {
+        NSObject<HPSection> *sec = [file sectionNamed:
+            [NSString stringWithFormat:@"text%u_%u", moduleId, header->prolog_section]];
+        if (sec) {
+            uint32_t offset = _bswap32(header->prolog_offset);
+            Address addr = sec.startAddress + offset;
+            [self recursiveMakeProcedures:[file makeProcedureAt:addr] file:file];
+            [file setName:[NSString stringWithFormat:@"_prolog%u", moduleId] forVirtualAddress:addr
+                   reason:NCReason_Import];
+        }
+    }
+    
+    // Epilog
+    if (header->epilog_section) {
+        NSObject<HPSection> *sec = [file sectionNamed:
+                                    [NSString stringWithFormat:@"text%u_%u", moduleId, header->epilog_section]];
+        if (sec) {
+            uint32_t offset = _bswap32(header->epilog_offset);
+            Address addr = sec.startAddress + offset;
+            [self recursiveMakeProcedures:[file makeProcedureAt:addr] file:file];
+            [file setName:[NSString stringWithFormat:@"_epilog%u", moduleId] forVirtualAddress:addr
+                   reason:NCReason_Import];
+        }
+    }
+    
+    // Unresolved
+    if (header->unresolved_section) {
+        NSObject<HPSection> *sec = [file sectionNamed:
+                                    [NSString stringWithFormat:@"text%u_%u", moduleId, header->unresolved_section]];
+        if (sec) {
+            uint32_t offset = _bswap32(header->unresolved_offset);
+            Address addr = sec.startAddress + offset;
+            [self recursiveMakeProcedures:[file makeProcedureAt:addr] file:file];
+            [file setName:[NSString stringWithFormat:@"_unresolved%u", moduleId] forVirtualAddress:addr
+                   reason:NCReason_Import];
+        }
+    }
+    
+    // Analyze text sections
+    NSObject<CPUContext> *context = [file buildCPUContext];
+    for (NSObject<HPSection> *sec in textSections) {
+        for (Address addr = sec.startAddress; addr < sec.endAddress;) {
+            NSUInteger padding = [context detectedPaddingLengthAt:addr];
+            if (padding) {
+                [file setType:Type_Align atVirtualAddress:addr forLength:padding];
+                addr += padding;
+            }
+            if (![file hasProcedureAt:addr])
+                [self recursiveMakeProcedures:[file makeProcedureAt:addr] file:file];
+            addr += 4;
+        }
+    }
+    
+    // Analyze data sections
+    for (NSObject<HPSection> *sec in dataSections) {
+        for (uint64_t offset = 0; offset < sec.fileLength; offset += 4) {
+            uint32_t data = _bswap32(*(uint32_t*)(bytes + sec.fileOffset + offset));
+            if (data >= 0x80000000 && data <= 0x8C000000) {
+                Address addr = sec.startAddress + offset;
+                [file setType:Type_Int32 atVirtualAddress:addr forLength:4];
+                [file setFormat:Format_Address forArgument:0 atVirtualAddress:addr];
+                [segment addReferencesToAddress:data fromAddress:addr];
+            }
+        }
+    }
+    
+    [_services.currentDocument endWaiting];
+}
+
+- (void)linkREL:(id)sender {
+    NSObject<HPDocument> *doc = [_services currentDocument];
+    NSMutableArray<HPSegment> *linkedSegments = [NSMutableArray<HPSegment> new];
+    for (NSObject<HPSegment> *seg in doc.disassembledFile.segments) {
+        if ([seg.segmentName isEqualToString:@"unnamed segment"]) {
+            const void *bytes = seg.mappedData.bytes;
+            uint32_t module_id = OSReadBigInt32(bytes, 0);
+            if (module_id == 0 || OSReadBigInt32(bytes, 4) != 0 || OSReadBigInt32(bytes, 8) != 0)
+                continue;
+            uint32_t version = OSReadBigInt32(bytes, 28);
+            if (version != 1 && version != 2 && version != 3)
+                continue;
+            
+            uint32_t sectionInfoOff = OSReadBigInt32(bytes, 16);
+            uint32_t importTableOff = OSReadBigInt32(bytes, 40);
+            if (sectionInfoOff >= seg.mappedData.length || importTableOff >= seg.mappedData.length)
+                continue;
+            
+            // Valid REL
+            NSInteger result = [doc displayAlertWithMessageText:@"Detected REL"
+                                                  defaultButton:@"Yes"
+                                                alternateButton:@"No"
+                                                    otherButton:nil
+                                                informativeText:
+                                [NSString stringWithFormat:@"Found REL data at 0x%" PRIX64 ". Link?", seg.startAddress]];
+            if (result == 1000) {
+                // First pass creates Hopper sections
+                [self _prelinkREL:seg file:doc.disassembledFile];
+                [linkedSegments addObject:seg];
+            }
+        }
+    }
+    
+    for (NSObject<HPSegment> *seg in linkedSegments) {
+        // Second pass resolves relocations from all candidate REL modules
+        [self _linkREL:seg file:doc.disassembledFile];
+    }
+    
+    if (!linkedSegments.count)
+        [doc displayAlertWithMessageText:@"Unnamed REL segment not detected"
+                           defaultButton:@"OK"
+                         alternateButton:nil
+                             otherButton:nil
+                         informativeText:@"Unable to find \"unnamed segment\" containing REL data"];
+}
+
+- (instancetype)initWithHopperServices:(NSObject <HPHopperServices> *)services {
+    if (self = [super init]) {
+        _services = services;
+    }
+    return self;
+}
+
+- (HopperUUID *)pluginUUID {
+    return [_services UUIDWithString:@"42056020-EB6F-469F-8E78-425CC767B145"];
+}
+
+- (HopperPluginType)pluginType {
+    return Plugin_Tool;
+}
+
+- (NSString *)pluginName {
+    return @"RELLinker";
+}
+
+- (NSString *)pluginDescription {
+    return @"REL Linker";
+}
+
+- (NSString *)pluginAuthor {
+    return @"Jack Andersen";
+}
+
+- (NSString *)pluginCopyright {
+    return @"©2018 - Jack Andersen";
+}
+
+- (NSString *)pluginVersion {
+    return @"0.0.1";
+}
+
+@end

--- a/REL_Linker/en.lproj/InfoPlist.strings
+++ b/REL_Linker/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+


### PR DESCRIPTION
This adds an additional tool plugin for linking REL files after being appended to the DOL using File > Load Additional Binary. Relocations are processed and code is patched as if Hopper's segment map were the GameCube's actual memory.