### PR TITLE
Bug fix with SPR name handling

### DIFF
--- a/PPCCPU/PPCCtx.m
+++ b/PPCCPU/PPCCtx.m
@@ -648,7 +648,7 @@ static int GetRegisterIndex(DisasmOperandType type)
                     andIndex:regIdx];
     }
     else if (operand->type & DISASM_OPERAND_OTHER) {
-        [line appendRegister:@(operand->userString)];
+        [line appendRegister:@(operand->userString + 8)];
     }
     
     [line setIsOperand:operandIndex startingAtIndex:0];
@@ -691,7 +691,7 @@ static const char* CRNames[] =
         op_index = 3;
     }
     
-    for (; op_index<=DISASM_MAX_OPERANDS; op_index++) {
+    for (; op_index<DISASM_MAX_OPERANDS; op_index++) {
         NSObject<HPASMLine> *part = [self buildOperandString:disasm forOperandIndex:op_index inFile:file raw:raw];
         if (part == nil) break;
         if (op_index) [line appendRawString:@", "];

--- a/PPCCPU/ppcd/ppcd.m
+++ b/PPCCPU/ppcd/ppcd.m
@@ -273,7 +273,7 @@ static void DISASM_PPC_BUILD_SPR_OP(int idx, bool write)
     DisasmOperand* op = &o->disasm->operand[o->opIdx++];
     op->type = DISASM_OPERAND_OTHER;
     op->type |= DISASM_BUILD_REGISTER_CLS_MASK(RegClass_SPRegister);
-    strcpy(op->userString, spr_name(idx));
+    strcpy(op->userString + 8, spr_name(idx));
     if (write) {
         op->accessMode = DISASM_ACCESS_WRITE;
     } else {
@@ -286,7 +286,7 @@ static void DISASM_PPC_BUILD_TBR_OP(int idx, bool write)
     DisasmOperand* op = &o->disasm->operand[o->opIdx++];
     op->type = DISASM_OPERAND_OTHER;
     op->type |= DISASM_BUILD_REGISTER_CLS_MASK(RegClass_TBRegister);
-    strcpy(op->userString, tbr_name(idx));
+    strcpy(op->userString + 8, tbr_name(idx));
     if (write) {
         op->accessMode = DISASM_ACCESS_WRITE;
     } else {


### PR DESCRIPTION
One more small commit. This one avoids clobbering the operand user flags when the userString field is populated (implemented as a union).